### PR TITLE
Add pytest coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install numpy pytest
+          python -m pip install numpy pytest pytest_cov
       - name: Build module with coverage
         run: |
           # Build the extension module in-place so pytest can find it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
   "bio2zarr @ git+https://github.com/sgkit-dev/bio2zarr.git",
   "cyvcf2",
   "pytest",
+  "pytest-cov",
   "pytest-datadir",
 ]
 
@@ -36,6 +37,7 @@ packages = ["vcztools"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--cov=vcztools --cov-report=term-missing"
 
 [tool.setuptools_scm]
 write_to = "vcztools/_version.py"


### PR DESCRIPTION
### Overview

This pull request adds pytest coverage to the vcztools project. I find the coverage information useful and think others might benefit from it as well.

This pull request makes progress on #56. What remains is to add the Coveralls configuration.

### Testing

I tested these changes manually by installing the dev requirements (`pip install -e ".[dev]") and then running the tests ('pytest tests'). These commands produce the desired coverage file.

### References

- [pytest project.toml configuration](https://docs.pytest.org/en/8.2.x/reference/customize.html#pyproject-toml)
- [pytest-cov configuration](https://pytest-cov.readthedocs.io/en/latest/config.html#reference)