### PR TITLE
Add query list samples command

### DIFF
--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -52,7 +52,7 @@ def run_vcztools(args: str) -> str:
     ]
 )
 # fmt: on
-def test(tmp_path, args, vcf_file):
+def test_vcf_output(tmp_path, args, vcf_file):
     original = pathlib.Path("tests/data/vcf") / vcf_file
     vcz = vcz_path_cache(original)
 
@@ -67,3 +67,20 @@ def test(tmp_path, args, vcf_file):
         f.write(vcztools_out)
 
     assert_vcfs_close(bcftools_out_file, vcztools_out_file)
+
+
+@pytest.mark.parametrize(
+    ("args", "vcf_name"),
+    [
+        ("query -l", "sample.vcf.gz"),
+        ("query --list-samples", "1kg_2020_chrM.vcf.gz"),
+    ],
+)
+def test_output(tmp_path, args, vcf_name):
+    vcf_path = pathlib.Path("tests/data/vcf") / vcf_name
+    vcz_path = vcz_path_cache(vcf_path)
+
+    bcftools_output = run_bcftools(f"{args} {vcf_path}")
+    vcztools_output = run_vcztools(f"{args} {vcz_path}")
+
+    assert vcztools_output == bcftools_output

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,15 @@
+import pathlib
+from io import StringIO
+
+from tests.utils import vcz_path_cache
+from vcztools.query import list_samples
+
+
+def test_list_samples(tmp_path):
+    vcf_path = pathlib.Path("tests/data/vcf") / "sample.vcf.gz"
+    vcz_path = vcz_path_cache(vcf_path)
+    expected_output = "NA00001\nNA00002\nNA00003\n"
+
+    with StringIO() as output:
+        list_samples(vcz_path, output)
+        assert output.getvalue() == expected_output

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -2,6 +2,7 @@ import sys
 
 import click
 
+from . import query as query_module
 from . import regions, vcf_writer
 
 
@@ -18,6 +19,20 @@ class NaturalOrderGroup(click.Group):
 @click.argument("path", type=click.Path())
 def index(path):
     regions.create_index(path)
+
+
+@click.command
+@click.argument("path", type=click.Path())
+@click.option(
+    "-l",
+    "--list-samples",
+    is_flag=True,
+    help="List the sample IDs and exit.",
+)
+def query(path, list_samples):
+    if list_samples:
+        query_module.list_samples(path)
+        return
 
 
 @click.command
@@ -96,4 +111,5 @@ def vcztools_main():
 
 
 vcztools_main.add_command(index)
+vcztools_main.add_command(query)
 vcztools_main.add_command(view)

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -1,0 +1,11 @@
+import zarr
+
+from vcztools.utils import open_file_like
+
+
+def list_samples(vcz_path, output=None):
+    root = zarr.open(vcz_path, mode="r")
+
+    with open_file_like(output) as output:
+        sample_ids = root["sample_id"][:]
+        print("\n".join(sample_ids), file=output)


### PR DESCRIPTION
### Overview

This pull request implements the `bcftools query --list-samples` command from bcftools in vcztools. The vcztools command loads the sample IDs from the VCF Zarr group and prints them.

This pull request closes #51.

### Example usage

```bash
vcztools query -l vcz_test_cache/sample.vcf.vcz
NA00001
NA00002
NA00003
vcztools query --list-samples vcz_test_cache/sample.vcf.vcz
NA00001
NA00002
NA00003
```

### Testing

I added some tests that compare bcftools' output with vcztools' output along with some unit tests. The code introduced in this pull request has good coverage.

~The coverage tool shows no coverage on the code added in this PR because the tests run the code in a different process. Most of the VCF writer code is also not covered because of this testing approach.~

### References

- [bcftools query](https://samtools.github.io/bcftools/bcftools.html#query)