### PR TITLE
Factor out `open_file_like` utility context manager

### DIFF
--- a/vcztools/utils.py
+++ b/vcztools/utils.py
@@ -1,5 +1,7 @@
 import functools
 import operator
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
 from typing import Callable
 
 import numpy as np
@@ -13,6 +15,16 @@ def search(a, v):
     sorter = np.argsort(a)
     rank = np.searchsorted(a, v, sorter=sorter)
     return sorter[rank]
+
+
+@contextmanager
+def open_file_like(file):
+    """A context manager for opening a file path or string (and closing on exit),
+    or passing a file-like object through."""
+    with ExitStack() as stack:
+        if isinstance(file, (str, Path)):
+            file = stack.enter_context(open(file, mode="w"))
+        yield file
 
 
 class FilterExpressionParser:

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -1,8 +1,6 @@
 import functools
 import io
 import re
-from contextlib import ExitStack
-from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -14,7 +12,12 @@ from vcztools.regions import (
     regions_to_chunk_indexes,
     regions_to_selection,
 )
-from vcztools.utils import FilterExpressionEvaluator, FilterExpressionParser, search
+from vcztools.utils import (
+    FilterExpressionEvaluator,
+    FilterExpressionParser,
+    open_file_like,
+    search,
+)
 
 from . import _vcztools
 from .constants import RESERVED_VARIABLE_NAMES
@@ -135,10 +138,7 @@ def write_vcf(
 
     root = zarr.open(vcz, mode="r")
 
-    with ExitStack() as stack:
-        if isinstance(output, str) or isinstance(output, Path):
-            output = stack.enter_context(open(output, mode="w"))
-
+    with open_file_like(output) as output:
         if samples is None:
             sample_ids = root["sample_id"][:]
             samples_selection = None


### PR DESCRIPTION
This will reduce duplication as we need this elsewhere (e.g. #58), and improves test coverage (see https://github.com/sgkit-dev/vcztools/pull/59#discussion_r1722247764).