### PR TITLE
Query format

### DIFF
--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -76,6 +76,10 @@ def test_vcf_output(tmp_path, args, vcf_file):
         ("index --nrecords", "1kg_2020_chrM.vcf.gz"),
         ("query -l", "sample.vcf.gz"),
         ("query --list-samples", "1kg_2020_chrM.vcf.gz"),
+        (r"query -f 'A\n'", "sample.vcf.gz"),
+        (r"query -f '%CHROM:%POS\n'", "sample.vcf.gz"),
+        (r"query -f '%INFO/DP\n'", "sample.vcf.gz"),
+        (r"query -f '%AC{0}\n'", "sample.vcf.gz"),
     ],
 )
 def test_output(tmp_path, args, vcf_name):

--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -80,6 +80,12 @@ def test_vcf_output(tmp_path, args, vcf_file):
         (r"query -f '%CHROM:%POS\n'", "sample.vcf.gz"),
         (r"query -f '%INFO/DP\n'", "sample.vcf.gz"),
         (r"query -f '%AC{0}\n'", "sample.vcf.gz"),
+        (r"query -f '%REF\t%ALT\n'", "sample.vcf.gz"),
+        (r"query -f '%ALT{1}\n'", "sample.vcf.gz"),
+        (r"query -f '%ID\n'", "sample.vcf.gz"),
+        (r"query -f '%QUAL\n'", "sample.vcf.gz"),
+        (r"query -f '%FILTER\n'", "sample.vcf.gz"),
+        (r"query --format '%FILTER\n'", "1kg_2020_chrM.vcf.gz"),
     ],
 )
 def test_output(tmp_path, args, vcf_name):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,8 +1,11 @@
 import pathlib
 from io import StringIO
 
+import pyparsing as pp
+import pytest
+
 from tests.utils import vcz_path_cache
-from vcztools.query import list_samples
+from vcztools.query import QueryFormatParser, list_samples
 
 
 def test_list_samples(tmp_path):
@@ -13,3 +16,49 @@ def test_list_samples(tmp_path):
     with StringIO() as output:
         list_samples(vcz_path, output)
         assert output.getvalue() == expected_output
+
+
+class TestQueryFormatParser:
+    @pytest.fixture()
+    def parser(self):
+        return QueryFormatParser()
+
+    @pytest.mark.parametrize(
+        ("expression", "expected_result"),
+        [
+            ("%CHROM", ["%CHROM"]),
+            (r"\n", ["\n"]),
+            (r"\t", ["\t"]),
+            (r"%CHROM\n", ["%CHROM", "\n"]),
+            ("%CHROM  %POS  %REF", ["%CHROM", "  ", "%POS", "  ", "%REF"]),
+            (r"%CHROM  %POS0  %REF\n", ["%CHROM", "  ", "%POS0", "  ", "%REF", "\n"]),
+            (
+                r"%CHROM\t%POS\t%REF\t%ALT{0}\n",
+                ["%CHROM", "\t", "%POS", "\t", "%REF", "\t", ["%ALT", 0], "\n"],
+            ),
+            (
+                r"%CHROM\t%POS0\t%END\t%ID\n",
+                ["%CHROM", "\t", "%POS0", "\t", "%END", "\t", "%ID", "\n"],
+            ),
+            (r"%CHROM:%POS\n", ["%CHROM", ":", "%POS", "\n"]),
+            (r"%AC{1}\n", [["%AC", 1], "\n"]),
+            (
+                r"Allelic depth: %INFO/AD\n",
+                ["Allelic", " ", "depth:", " ", "%INFO/AD", "\n"],
+            ),
+        ],
+    )
+    def test_valid_expressions(self, parser, expression, expected_result):
+        assert parser(expression).as_list() == expected_result
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            ("%ac",),
+            ("%AC {1}",),
+            ("% CHROM",),
+        ],
+    )
+    def test_invalid_expressions(self, parser, expression):
+        with pytest.raises(pp.ParseException):
+            parser(expression)

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -38,10 +38,13 @@ def index(path, nrecords):
     is_flag=True,
     help="List the sample IDs and exit.",
 )
-def query(path, list_samples):
+@click.option("-f", "--format", type=str, help="The format of the output.")
+def query(path, list_samples, format):
     if list_samples:
         query_module.list_samples(path)
         return
+
+    query_module.write_query(path, query_format=format)
 
 
 @click.command

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -1,9 +1,13 @@
 import functools
+import itertools
+import math
+from typing import Callable, Union
 
+import numpy as np
 import pyparsing as pp
 import zarr
 
-from vcztools.utils import open_file_like
+from vcztools.utils import open_file_like, vcf_name_to_vcz_name
 
 
 def list_samples(vcz_path, output=None):
@@ -47,3 +51,120 @@ class QueryFormatParser:
         assert not kwargs
 
         return self._parser(args[0])
+
+
+class QueryFormatGenerator:
+    def __init__(self, query_format: Union[str, pp.ParseResults]):
+        if isinstance(query_format, str):
+            parser = QueryFormatParser()
+            parse_results = parser(query_format)
+        else:
+            assert isinstance(query_format, pp.ParseResults)
+            parse_results = query_format
+
+        self._generator = self._compose_generator(parse_results)
+
+    def __call__(self, *args, **kwargs):
+        assert len(args) == 1
+        assert not kwargs
+
+        yield from self._generator(args[0])
+
+    def _compose_tag_generator(self, tag: str, *, subscript=False) -> Callable:
+        assert tag.startswith("%")
+        tag = tag[1:]
+
+        def generate(root):
+            vcz_names = set(name for name, _zarray in root.items())
+            vcz_name = vcf_name_to_vcz_name(vcz_names, tag)
+            zarray = root[vcz_name]
+            contig_ids = root["contig_id"][:] if tag == "CHROM" else None
+            filter_ids = root["filter_id"][:] if tag == "FILTER" else None
+            v_chunk_size = zarray.chunks[0]
+
+            for v_chunk_index in range(zarray.cdata_shape[0]):
+                start = v_chunk_index * v_chunk_size
+                end = start + v_chunk_size
+
+                for row in zarray[start:end]:
+                    is_missing = np.any(row == -1)
+
+                    if tag == "CHROM":
+                        assert contig_ids is not None
+                        row = contig_ids[row]
+                    if tag == "REF":
+                        row = row[0]
+                    if tag == "ALT":
+                        row = [allele for allele in row[1:] if allele]
+                        row = row or "."
+                    if tag == "FILTER":
+                        assert filter_ids is not None
+
+                        if np.any(row):
+                            row = filter_ids[row]
+                        else:
+                            row = "."
+                    if tag == "QUAL":
+                        if math.isnan(row):
+                            row = "."
+                        else:
+                            row = f"{row:g}"
+                    if not subscript and (
+                        isinstance(row, np.ndarray) or isinstance(row, list)
+                    ):
+                        row = ",".join(map(str, row))
+
+                    yield row if not is_missing else "."
+
+        return generate
+
+    def _compose_subscript_generator(self, parse_results: pp.ParseResults) -> Callable:
+        assert len(parse_results) == 2
+
+        tag, subscript_index = parse_results
+        tag_generator = self._compose_tag_generator(tag, subscript=True)
+
+        def generate(root):
+            for tag in tag_generator(root):
+                if isinstance(tag, str):
+                    assert tag == "."
+                    yield "."
+                else:
+                    if subscript_index < len(tag):
+                        yield tag[subscript_index]
+                    else:
+                        yield "."
+
+        return generate
+
+    def _compose_element_generator(
+        self, element: Union[str, pp.ParseResults]
+    ) -> Callable:
+        if isinstance(element, pp.ParseResults):
+            return self._compose_subscript_generator(element)
+
+        assert isinstance(element, str)
+
+        if element.startswith("%"):
+            return self._compose_tag_generator(element)
+        else:
+
+            def generate(root):
+                variant_count = root["variant_position"].shape[0]
+                yield from itertools.repeat(element, variant_count)
+
+            return generate
+
+    def _compose_generator(self, parse_results: pp.ParseResults) -> Callable:
+        generators = (
+            self._compose_element_generator(element) for element in parse_results
+        )
+
+        def generate(root) -> str:
+            iterables = (generator(root) for generator in generators)
+
+            for results in zip(*iterables):
+                results = map(str, results)
+                yield "".join(results)
+
+        return generate

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -168,3 +168,12 @@ class QueryFormatGenerator:
                 yield "".join(results)
 
         return generate
+
+
+def write_query(vcz, output=None, *, query_format: str):
+    root = zarr.open(vcz, mode="r")
+    generator = QueryFormatGenerator(query_format)
+
+    with open_file_like(output) as output:
+        for result in generator(root):
+            print(result, sep="", end="", file=output)

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -1,3 +1,6 @@
+import functools
+
+import pyparsing as pp
 import zarr
 
 from vcztools.utils import open_file_like
@@ -9,3 +12,38 @@ def list_samples(vcz_path, output=None):
     with open_file_like(output) as output:
         sample_ids = root["sample_id"][:]
         print("\n".join(sample_ids), file=output)
+
+
+class QueryFormatParser:
+    def __init__(self):
+        info_tag_pattern = pp.Combine(
+            pp.Literal("%INFO/") + pp.Word(pp.srange("[A-Z]"))
+        )
+        tag_pattern = info_tag_pattern | pp.Combine(
+            pp.Literal("%") + pp.Regex(r"[A-Z]+\d?")
+        )
+        subscript_pattern = pp.Group(
+            tag_pattern
+            + pp.Literal("{").suppress()
+            + pp.common.integer
+            + pp.Literal("}").suppress()
+        )
+        newline_pattern = pp.Literal("\\n").set_parse_action(pp.replace_with("\n"))
+        tab_pattern = pp.Literal("\\t").set_parse_action(pp.replace_with("\t"))
+        pattern = pp.ZeroOrMore(
+            subscript_pattern
+            | tag_pattern
+            | newline_pattern
+            | tab_pattern
+            | pp.White()
+            | pp.Word(pp.printables, exclude_chars=r"\{}[]%")
+        )
+        pattern = pattern.leave_whitespace()
+
+        self._parser = functools.partial(pattern.parse_string, parse_all=True)
+
+    def __call__(self, *args, **kwargs):
+        assert len(args) == 1
+        assert not kwargs
+
+        return self._parser(args[0])


### PR DESCRIPTION
### Overview

This pull request partially implements the [`query --format`](https://samtools.github.io/bcftools/bcftools.html#query) functionality from bcftools.

This pull request closes #50.

### Approach

The approach consists of two components: a parser and a generator. The parser processes the query format string and produces a format specifiers list. The generator is a function that takes the root VCF Zarr group and generates the result of the query one line at a time. The generator's initializer composes the generator according to the structure of the format specifiers list.

### Parser

I implement the parser using [PyParsing](https://pyparsing-docs.readthedocs.io/en/latest/). We used PyParsing to implement a parser in #49 as well.

### Generator

The generator uses Python generators to yield query results one variant position at a time. This approach allows Python to iterate over each Zarr array's chunks independently. The high-level generator zips generators for each of the format specifiers and joins the results to produce a line for each variant position.

### Query format language

This implementation does not support the full query format language that bcftools supports.

Here is what this implementation should support:
- any variant-site-level field except the full INFO field,
- newline characters,
- tab characters,
- subfield indexing with curly brackets.

This implementation does not support looping over samples at a variant site. Additionally, some format specifiers supported by bcftools are recognized by this implementation's parser but lead to an error in the generator (e.g. `%END0`).

### Testing

I add unit tests and validation tests along with my changes. I ran the test suite to check that my changes have good coverage.

### Example usage

```
vcztools query vcz_test_cache/sample.vcf.vcz -f "%REF\t%ALT\n"
A       C
A       G
G       A
T       A
A       G,T
T       .
G       GA,GAC
T       .
AC      A,ATG,C
```

### References

- [bcftools query](https://samtools.github.io/bcftools/bcftools.html#query)
- [PyParsing](https://pyparsing-docs.readthedocs.io/en/latest/)