### PR TITLE
Query variant filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+.vscode
+vcz_test_cache/

--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -126,6 +126,8 @@ def test_vcf_output_with_output_option(tmp_path, args, vcf_file):
         (r"query -f '%QUAL\n'", "sample.vcf.gz"),
         (r"query -f '%FILTER\n'", "sample.vcf.gz"),
         (r"query --format '%FILTER\n'", "1kg_2020_chrM.vcf.gz"),
+        (r"query -f '%POS\n' -i 'POS=112'", "sample.vcf.gz"),
+        (r"query -f '%POS\n' -e 'POS=112'", "sample.vcf.gz")
     ],
 )
 def test_output(tmp_path, args, vcf_name):

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -55,12 +55,16 @@ def index(path, nrecords, stats):
     help="List the sample IDs and exit.",
 )
 @click.option("-f", "--format", type=str, help="The format of the output.")
-def query(path, list_samples, format):
+@include
+@exclude
+def query(path, list_samples, format, include, exclude):
     if list_samples:
         query_module.list_samples(path)
         return
 
-    query_module.write_query(path, query_format=format)
+    query_module.write_query(
+        path, query_format=format, include=include, exclude=exclude
+    )
 
 
 @click.command

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -6,6 +6,13 @@ from . import query as query_module
 from . import regions, vcf_writer
 from . import stats as stats_module
 
+include = click.option(
+    "-i", "--include", type=str, help="Filter expression to include variant sites."
+)
+exclude = click.option(
+    "-e", "--exclude", type=str, help="Filter expression to exclude variant sites."
+)
+
 
 class NaturalOrderGroup(click.Group):
     """
@@ -122,12 +129,8 @@ def query(path, list_samples, format):
     default=None,
     help="Target regions to include.",
 )
-@click.option(
-    "-i", "--include", type=str, help="Filter expression to include variant sites."
-)
-@click.option(
-    "-e", "--exclude", type=str, help="Filter expression to exclude variant sites."
-)
+@include
+@exclude
 def view(
     path,
     output,

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 import math
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import pyparsing as pp
@@ -170,7 +170,19 @@ class QueryFormatGenerator:
         return generate
 
 
-def write_query(vcz, output=None, *, query_format: str):
+def write_query(
+    vcz,
+    output=None,
+    *,
+    query_format: str,
+    include: Optional[str] = None,
+    exclude: Optional[str] = None,
+):
+    if include and exclude:
+        raise ValueError(
+            "Cannot handle both an include expression and an exclude expression."
+        )
+
     root = zarr.open(vcz, mode="r")
     generator = QueryFormatGenerator(query_format)
 


### PR DESCRIPTION
### Overview

This pull request adds support for variant-site filtering in the `vcztools query` CLI. These changes mimic the filtering expression behavior in bcftools.

This pull request partially addresses #73. I reuse Python components added in #49 to implement these changes.

I also included some small gitignore updates in this pull request.

### Testing

I added some unit and validation tests. The query.py coverage was reported as 100%. I'm happy to add more tests if desired.

### Usage

```
vcztools query -f "%POS\n" vcz_test_cache/sample.vcf.vcz -i "POS=112"
112
```

### References

- [bcftools query](https://samtools.github.io/bcftools/bcftools.html#query)
- [bcftools filtering expressions](https://samtools.github.io/bcftools/bcftools.html#expressions)