### PR TITLE
Get INFO/FORMAT description from attrs if present

### DIFF
--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -445,8 +445,6 @@ def _generate_header(ds, original_header, sample_ids, *, no_version: bool = Fals
         # [1.4.1 File format]
         print("##fileformat=VCFv4.3", file=output)
 
-        print('##FILTER=<ID=PASS,Description="All filters passed">', file=output)
-
         if "source" in ds.attrs:
             print(f'##source={ds.attrs["source"]}', file=output)
 

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -489,10 +489,9 @@ def _generate_header(ds, original_header, sample_ids, *, no_version: bool = Fals
         category = "INFO"
         vcf_number = _array_to_vcf_number(category, key, arr)
         vcf_type = _array_to_vcf_type(arr)
-        if "comment" in arr.attrs:
-            vcf_description = arr.attrs["comment"]
-        else:
-            vcf_description = RESERVED_INFO_KEY_DESCRIPTIONS.get(key, "")
+        vcf_description = arr.attrs.get(
+            "description", RESERVED_INFO_KEY_DESCRIPTIONS.get(key, "")
+        )
         print(
             f'##INFO=<ID={key},Number={vcf_number},Type={vcf_type},Description="{vcf_description}">',
             file=output,
@@ -514,10 +513,9 @@ def _generate_header(ds, original_header, sample_ids, *, no_version: bool = Fals
             category = "FORMAT"
             vcf_number = _array_to_vcf_number(category, key, arr)
             vcf_type = _array_to_vcf_type(arr)
-            if "comment" in arr.attrs:
-                vcf_description = arr.attrs["comment"]
-            else:
-                vcf_description = RESERVED_FORMAT_KEY_DESCRIPTIONS.get(key, "")
+            vcf_description = arr.attrs.get(
+                "description", RESERVED_FORMAT_KEY_DESCRIPTIONS.get(key, "")
+            )
             print(
                 f'##FORMAT=<ID={key},Number={vcf_number},Type={vcf_type},Description="{vcf_description}">',
                 file=output,


### PR DESCRIPTION
The code in sgkit actually looks for `comment` keys in the attrs to populate the INFO/FORMAT description, whereas bio2zarr uses the `description` key.

This changes `vcztools` to be consistent with bio2zarr, and adds a test for generated headers.

This might be something we want to add to the spec.