### PR TITLE
Performance tests

### DIFF
--- a/performance/compare.py
+++ b/performance/compare.py
@@ -1,3 +1,12 @@
+# This script requires pv.
+
+# https://www.ivarch.com/programs/pv.shtml
+
+# There is a Homebrew formula to install pv on macOS.
+
+# This script also depends on the simulation data:
+# make -C data
+
 import subprocess
 import sys
 

--- a/performance/compare.py
+++ b/performance/compare.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+
+
+def run_time_pv(command: str):
+    print(command)
+    subprocess.run(f"time {command} | pv > /dev/null", shell=True)
+    print()
+
+
+def run_bcftools(command: str, dataset_name: str):
+    run_time_pv(f"bcftools {command} data/{dataset_name}.vcf.gz")
+
+
+def run_vcztools(command: str, dataset_name: str):
+    run_time_pv(f"vcztools {command} data/{dataset_name}.vcz")
+
+
+if __name__ == "__main__":
+    commands = [
+        "view",
+        "view -s tsk_7068,tsk_8769,tsk_8820",
+        r"query -f '%CHROM %POS %REF %ALT{0}\n'",
+        r"query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415'",
+        "view -s '' --force-samples",
+    ]
+    dataset = "sim_10k"
+
+    if len(sys.argv) == 2 and sys.argv[1].isnumeric():
+        index = int(sys.argv[1])
+        command = commands[index]
+        run_bcftools(command, dataset)
+        run_vcztools(command, dataset)
+    elif len(sys.argv) >= 2:
+        command = " ".join(sys.argv[1:])
+        run_bcftools(command, dataset)
+        run_vcztools(command, dataset)
+    else:
+        for command in commands:
+            run_bcftools(command, dataset)
+            run_vcztools(command, dataset)

--- a/performance/data/.gitignore
+++ b/performance/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!Makefile

--- a/performance/data/.gitignore
+++ b/performance/data/.gitignore
@@ -1,2 +1,3 @@
 *
 !Makefile
+!requirements.txt

--- a/performance/data/Makefile
+++ b/performance/data/Makefile
@@ -1,3 +1,14 @@
+# The make recipes require bcftools and bgzip.
+
+# https://samtools.github.io/bcftools/howtos/install.html
+# https://www.htslib.org/doc/bgzip.html
+
+# On macOS, there are Homebrew formulas for bcftools and htslib,
+# which contains bgzip.
+
+# The Python requirements are listed in requirements.txt:
+# pip install -r requirements.txt
+
 .PHONY: all clean
 
 all: sim_10k.vcz

--- a/performance/data/Makefile
+++ b/performance/data/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all clean
+
+all: sim_10k.vcz
+
+sim_10k.ts:
+	stdpopsim HomSap -c chr22 -o sim_10k.ts pop_0:10000
+
+sim_10k.vcf.gz: sim_10k.ts
+	tskit vcf sim_10k.ts | bgzip > sim_10k.vcf.gz
+
+sim_10k.vcf.gz.csi: sim_10k.vcf.gz
+	bcftools index sim_10k.vcf.gz
+
+sim_10k.vcz: sim_10k.vcf.gz sim_10k.vcf.gz.csi
+	vcf2zarr convert sim_10k.vcf.gz sim_10k.vcz
+
+clean:
+	rm -rf sim_10k.*

--- a/performance/data/requirements.txt
+++ b/performance/data/requirements.txt
@@ -1,0 +1,3 @@
+stdpopsim
+tskit
+bio2zarr


### PR DESCRIPTION
### Overview

This pull request adds performance tests and closes #55.

### Usage

To create the simulated testing data, run `make -C performance/data` from the project root.

Creating the testing data requires several tools: stdpopsim, tskit, bgzip, bcftools, and vcf2zarr.

To compare performance for all commands:

```shell
cd performance
python -m compare
```

```
bcftools view data/sim_10k.vcf.gz
10.2GiB 0:01:05 [ 159MiB/s] [                                                                                           <=>                                           ]

real    1m5.386s
user    1m4.818s
sys     0m2.131s

vcztools view data/sim_10k.vcz
10.2GiB 0:00:29 [ 358MiB/s] [                                                                                <=>                                                      ]

real    0m29.219s
user    0m34.108s
sys     0m3.471s

bcftools view -s tsk_7068,tsk_8769,tsk_8820 data/sim_10k.vcf.gz
13.9MiB 0:00:50 [ 285KiB/s] [                                                                                                                                   <=>   ]

real    0m50.004s
user    0m49.589s
sys     0m0.330s

vcztools view -s tsk_7068,tsk_8769,tsk_8820 data/sim_10k.vcz
13.9MiB 0:00:02 [6.72MiB/s] [        <=>                                                                                                                              ]

real    0m2.078s
user    0m3.413s
sys     0m0.681s

bcftools query -f '%CHROM %POS %REF %ALT{0}\n' data/sim_10k.vcf.gz
3.86MiB 0:00:04 [ 842KiB/s] [             <=>                                                                                                                         ]

real    0m4.694s
user    0m4.574s
sys     0m0.095s

vcztools query -f '%CHROM %POS %REF %ALT{0}\n' data/sim_10k.vcz
3.86MiB 0:00:04 [ 865KiB/s] [             <=>                                                                                                                         ]

real    0m4.569s
user    0m4.773s
sys     0m0.359s

bcftools query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415' data/sim_10k.vcf.gz
22.0  B 0:00:04 [4.78  B/s] [  <=>                                                                                                                                    ]

real    0m4.605s
user    0m4.518s
sys     0m0.085s

vcztools query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415' data/sim_10k.vcz
22.0  B 0:00:02 [9.66  B/s] [  <=>                                                                                                                                    ]

real    0m2.279s
user    0m2.754s
sys     0m0.281s

bcftools view -s '' --force-samples data/sim_10k.vcf.gz
Warn: subset called for sample that does not exist in header: ""... skipping
Warn: subsetting has removed all samples
11.5MiB 0:00:50 [ 235KiB/s] [                                                                                                                                   <=>   ]

real    0m50.049s
user    0m49.698s
sys     0m0.338s

vcztools view -s '' --force-samples data/sim_10k.vcz
12.0MiB 0:00:12 [ 984KiB/s] [                                <=>                                                                                                      ]

real    0m12.490s
user    0m15.680s
sys     0m1.768s
```

To select a command by index:
```shell
cd performance
python -m compare 2
```

```
bcftools query -f '%CHROM %POS %REF %ALT{0}\n' data/sim_10k.vcf.gz
3.86MiB 0:00:04 [ 861KiB/s] [             <=>                                                                                                                         ]

real    0m4.591s
user    0m4.451s
sys     0m0.093s

vcztools query -f '%CHROM %POS %REF %ALT{0}\n' data/sim_10k.vcz
3.86MiB 0:00:04 [ 842KiB/s] [             <=>                                                                                                                         ]

real    0m4.697s
user    0m5.183s
sys     0m0.431s
```

To manually compare a command:
```shell
cd performance
python -m compare query --list-samples
```

```
bcftools query --list-samples data/sim_10k.vcf.gz
86.8KiB 0:00:00 [7.62MiB/s] [  <=>                                                                                                                                    ]

real    0m0.014s
user    0m0.005s
sys     0m0.004s

vcztools query --list-samples data/sim_10k.vcz
86.8KiB 0:00:00 [ 109KiB/s] [  <=>                                                                                                                                    ]

real    0m0.797s
user    0m1.324s
sys     0m0.521s
```

### Testing

I tested the Makefile and the compare script manually.