### PR TITLE
Add real performance testing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 
 .vscode
 vcz_test_cache/
+**/.DS_Store

--- a/performance/compare.py
+++ b/performance/compare.py
@@ -32,6 +32,9 @@ if __name__ == "__main__":
         (r"query -f '%CHROM %POS %REF %ALT{0}\n'", "sim_10k"),
         (r"query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415'", "sim_10k"),
         ("view -s '' --force-samples", "sim_10k"),
+        ("view -i 'FMT/DP>10 & FMT/GQ>10'", "chr22"),
+        ("view -i 'QUAL>10 || FMT/GQ>10'", "chr22"),
+        (r"query -f 'GQ:[ %GQ] \t GT:[ %GT]\n'", "chr22"),
     ]
 
     if len(sys.argv) == 2 and sys.argv[1].isnumeric():

--- a/performance/compare.py
+++ b/performance/compare.py
@@ -27,24 +27,19 @@ def run_vcztools(command: str, dataset_name: str):
 
 if __name__ == "__main__":
     commands = [
-        "view",
-        "view -s tsk_7068,tsk_8769,tsk_8820",
-        r"query -f '%CHROM %POS %REF %ALT{0}\n'",
-        r"query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415'",
-        "view -s '' --force-samples",
+        ("view", "sim_10k"),
+        ("view -s tsk_7068,tsk_8769,tsk_8820", "sim_10k"),
+        (r"query -f '%CHROM %POS %REF %ALT{0}\n'", "sim_10k"),
+        (r"query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415'", "sim_10k"),
+        ("view -s '' --force-samples", "sim_10k"),
     ]
-    dataset = "sim_10k"
 
     if len(sys.argv) == 2 and sys.argv[1].isnumeric():
         index = int(sys.argv[1])
-        command = commands[index]
-        run_bcftools(command, dataset)
-        run_vcztools(command, dataset)
-    elif len(sys.argv) >= 2:
-        command = " ".join(sys.argv[1:])
+        command, dataset = commands[index]
         run_bcftools(command, dataset)
         run_vcztools(command, dataset)
     else:
-        for command in commands:
+        for command, dataset in commands:
             run_bcftools(command, dataset)
             run_vcztools(command, dataset)

--- a/performance/data/Makefile
+++ b/performance/data/Makefile
@@ -9,12 +9,30 @@
 # The Python requirements are listed in requirements.txt:
 # pip install -r requirements.txt
 
-.PHONY: all clean
+# Flags / commandline arguments:
+CHROMOSOME ?= 22
+WGS ?= 1
 
-all: sim_10k.vcz
+ifeq ($(WGS), 1)
+        TGP_URL = "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/working/20190425_NYGC_GATK/CCDG_13607_B01_GRM_WGS_2019-02-19_chr$(CHROMOSOME).recalibrated_variants.vcf.gz"
+else
+        # Use URL for genotyping data:
+        TGP_URL = "http://hgdownload.cse.ucsc.edu/gbdb/hg19/1000Genomes/phase3/ALL.chr$(CHROMOSOME).phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz"
+endif
+
+.PHONY: all simulated real clean
+
+all: simulated real
+
+simulated: sim_10k.vcz
+
+real: chr22.vcz
 
 sim_10k.ts:
 	stdpopsim HomSap -c chr22 -o sim_10k.ts pop_0:10000
+
+chr22.vcf.gz:
+	bcftools view $(TGP_URL) | head -n 25000 | bcftools view -O z -o chr22.vcf.gz
 
 %.vcf.gz: %.ts
 	tskit vcf $< | bgzip > $@

--- a/performance/data/Makefile
+++ b/performance/data/Makefile
@@ -16,14 +16,14 @@ all: sim_10k.vcz
 sim_10k.ts:
 	stdpopsim HomSap -c chr22 -o sim_10k.ts pop_0:10000
 
-sim_10k.vcf.gz: sim_10k.ts
-	tskit vcf sim_10k.ts | bgzip > sim_10k.vcf.gz
+%.vcf.gz: %.ts
+	tskit vcf $< | bgzip > $@
 
-sim_10k.vcf.gz.csi: sim_10k.vcf.gz
-	bcftools index sim_10k.vcf.gz
+%.vcf.gz.csi: %.vcf.gz
+	bcftools index $<
 
-sim_10k.vcz: sim_10k.vcf.gz sim_10k.vcf.gz.csi
-	vcf2zarr convert sim_10k.vcf.gz sim_10k.vcz
+%.vcz: %.vcf.gz %.vcf.gz.csi
+	vcf2zarr convert $< $@
 
 clean:
 	rm -rf sim_10k.*


### PR DESCRIPTION
### Overview

We want to understand vcztools' performance compared to bcftools. This pull request adds Makefile rules to download real genome data that we can test vcztools' performance with. The Makefile rules are mostly copied from the [VCF Zarr publication repo](https://github.com/sgkit-dev/vcf-zarr-publication/blob/main/real_data/Makefile). I modified the amount of data that the Makefile downloads so that the WGS file is ~250MB.

I also add some new performance testing commands in this pull request.

### Results

The performance commands I added are slower on vcztools than bcftools, revealing some opportunities for improvement.

```shell
python -m compare 5 && python -m compare 6 && python -m compare 7
```

```shell
bcftools view -i 'FMT/DP>10 & FMT/GQ>10' data/chr22.vcf.gz
1.66GiB 0:00:11 [ 144MiB/s] [                            <=>                                                                                           ]

real    0m11.798s
user    0m11.278s
sys     0m0.508s

vcztools view -i 'FMT/DP>10 & FMT/GQ>10' data/chr22.vcz
1.66GiB 0:00:45 [37.4MiB/s] [                                                         <=>                                                              ]

real    0m45.604s
user    0m33.547s
sys     0m10.717s

bcftools view -i 'QUAL>10 || FMT/GQ>10' data/chr22.vcf.gz
1.67GiB 0:00:11 [ 154MiB/s] [                            <=>                                                                                           ]

real    0m11.103s
user    0m10.735s
sys     0m0.480s

vcztools view -i 'QUAL>10 || FMT/GQ>10' data/chr22.vcz
1.67GiB 0:00:42 [40.0MiB/s] [                                                           <=>                                                            ]

real    0m42.707s
user    0m32.329s
sys     0m10.241s

bcftools query -f 'GQ:[ %GQ] \t GT:[ %GT]\n' data/chr22.vcf.gz
 349MiB 0:00:08 [40.8MiB/s] [                     <=>                                                                                                  ]

real    0m8.581s
user    0m8.479s
sys     0m0.212s

vcztools query -f 'GQ:[ %GQ] \t GT:[ %GT]\n' data/chr22.vcz
 349MiB 0:00:51 [6.85MiB/s] [                                                                                                                  <=>     ]

real    0m51.060s
user    0m51.190s
sys     0m0.757s
```

### Testing

I tested these changes manually.