### PR TITLE
vcztools view performance

### DIFF
--- a/performance/compare.py
+++ b/performance/compare.py
@@ -28,6 +28,7 @@ def run_vcztools(command: str, dataset_name: str):
 if __name__ == "__main__":
     commands = [
         ("view", "sim_10k"),
+        ("view", "chr22"),
         ("view -s tsk_7068,tsk_8769,tsk_8820", "sim_10k"),
         (r"query -f '%CHROM %POS %REF %ALT{0}\n'", "sim_10k"),
         (r"query -f '%CHROM:%POS\n' -i 'POS=49887394 | POS=50816415'", "sim_10k"),

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -151,7 +151,7 @@ def view(
     include,
     exclude,
 ):
-    if output and not output.endswith(".vcf"):
+    if output and not output.endswith(".vcf") and output != "/dev/null":
         split = output.split(".")
         raise ValueError(f"Output file extension must be .vcf, got: .{split[-1]}")
 


### PR DESCRIPTION
### Overview

This pull request adds the `view` command to the set of performance testing commands.

This pull request also closes #92.

### Testing

I ran the new performance command manually.

For the #92 fix, I verified the fix by running `vcztools view performance/data/chr22.vcz -o /dev/null`.

### Results

```shell
cd performance
python -m compare 1
```

```
bcftools view data/chr22.vcf.gz
1.67GiB 0:00:10 [ 156MiB/s] [                             <=>                                                                                                         ]

real    0m10.931s
user    0m10.356s
sys     0m0.522s

vcztools view data/chr22.vcz
1.67GiB 0:00:40 [42.4MiB/s] [                                                                <=>                                                                      ]

real    0m40.290s
user    0m31.387s
sys     0m9.024s
```

### Profiling

```python
cProfile.run('write_vcf("performance/data/chr22.vcz", os.devnull)', sort=SortKey.TIME)
```

```
         182103 function calls in 39.822 seconds
   Ordered by: internal time
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    21541   20.241    0.001   20.241    0.001 {method 'encode' of '_vcztools.VcfEncoder' objects}
      164    7.864    0.048    7.870    0.048 core.py:2343(_decode_chunk)
       26    6.919    0.266    6.919    0.266 {method 'astype' of 'numpy.ndarray' objects}
      220    2.659    0.012   10.533    0.048 core.py:2013(_process_chunk)
        1    0.810    0.810   39.822   39.822 vcf_writer.py:80(write_vcf)
      140    0.498    0.004   11.178    0.080 core.py:2108(_chunk_getitems)
      140    0.310    0.002   11.490    0.082 core.py:1316(_get_selection)
        3    0.162    0.054   38.963   12.988 vcf_writer.py:284(c_chunk_to_vcf)
      499    0.159    0.000    0.159    0.000 {method 'read' of '_io.BufferedReader' objects}
    25005    0.115    0.000    0.115    0.000 {built-in method builtins.print}
      500    0.011    0.000    0.011    0.000 {built-in method io.open}
```

### References

- [Python profilers](https://docs.python.org/3.12/library/profile.html)
