### PR TITLE
Py39

### DIFF
--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -12,7 +12,5 @@ from vcztools.regions import parse_region_string
         ("chr1:12-103", ("chr1", 12, 103)),
     ],
 )
-def test_parse_region_string(
-    targets: str, expected: tuple[str, int | None, int | None]
-):
+def test_parse_region_string(targets, expected):
     assert parse_region_string(targets) == expected

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import itertools
 import math

--- a/vcztools/regions.py
+++ b/vcztools/regions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 from typing import Any
 

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import concurrent.futures
 import functools
 import io


### PR DESCRIPTION
I would like to reinstate support for Python 3.9 as the server I am working to do benchmarks on has it installed as system Python, and I am very much disinclined to change it. We don't need to support it as an official platform, but I would appreciate it if we could not add things requiring > py39 until we have to.

Python 3.9 is a perfectly good platform, and I see no good reason to be pushed off it for a good few years yet.

The only thing that makes our code here non Python 3.9 compatible are the type annotations, which I have to say I doubly resent now. Not only are they not particularly useful, resulting in a bunch of pointless churn and often substantially less readable code, but they are actively creating work now by forcing us away from Python 3.9.

@tomwhite - would you prefer that I add ``from __future__ import annotations`` to all the files here or delete the offending annotations (I'd prefer to just delete them, or make them less precise).