### PR TITLE
Backward and forward-compatible changes to support zarr-python v3

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -56,7 +56,7 @@ def main(root):
     # we avoid retrieving stuff we don't need.
     format_fields = {}
     info_fields = {}
-    for name, array in root.items():
+    for name, array in root.arrays():
         if name.startswith("call_") and not name.startswith("call_genotype"):
             vcf_name = name[len("call_") :]
             format_fields[vcf_name] = array.blocks[v_chunk]

--- a/vcztools/filter.py
+++ b/vcztools/filter.py
@@ -113,7 +113,7 @@ class FilterExpressionEvaluator:
 
         def evaluator(root, variant_chunk_index: int) -> np.ndarray:
             vcf_name = parse_results[0]
-            vcz_names = set(name for name, _array in root.items())
+            vcz_names = set(root.keys())
             vcz_name = vcf_name_to_vcz_name(vcz_names, vcf_name)
             zarray = root[vcz_name]
             variant_chunk_len = zarray.chunks[0]

--- a/vcztools/query.py
+++ b/vcztools/query.py
@@ -141,7 +141,7 @@ class QueryFormatGenerator:
             return self._compose_sample_ids_generator()
 
         def generate(root):
-            vcz_names = set(name for name, _zarray in root.items())
+            vcz_names = set(root.keys())
             vcz_name = vcf_name_to_vcz_name(vcz_names, tag)
             zarray = root[vcz_name]
             contig_ids = root["contig_id"][:] if tag == "CHROM" else None

--- a/vcztools/vcf_writer.py
+++ b/vcztools/vcf_writer.py
@@ -309,15 +309,15 @@ def c_chunk_to_vcf(
     no_update,
     preceding_future: concurrent.futures.Future | None = None,
 ):
-    chrom = contigs[get_vchunk_array(root.variant_contig, v_chunk, v_mask_chunk)]
+    chrom = contigs[get_vchunk_array(root["variant_contig"], v_chunk, v_mask_chunk)]
     # TODO check we don't truncate silently by doing this
-    pos = get_vchunk_array(root.variant_position, v_chunk, v_mask_chunk).astype(
+    pos = get_vchunk_array(root["variant_position"], v_chunk, v_mask_chunk).astype(
         np.int32
     )
-    id = get_vchunk_array(root.variant_id, v_chunk, v_mask_chunk).astype("S")
-    alleles = get_vchunk_array(root.variant_allele, v_chunk, v_mask_chunk)
-    qual = get_vchunk_array(root.variant_quality, v_chunk, v_mask_chunk)
-    filter_ = get_vchunk_array(root.variant_filter, v_chunk, v_mask_chunk)
+    id = get_vchunk_array(root["variant_id"], v_chunk, v_mask_chunk).astype("S")
+    alleles = get_vchunk_array(root["variant_allele"], v_chunk, v_mask_chunk)
+    qual = get_vchunk_array(root["variant_quality"], v_chunk, v_mask_chunk)
+    filter_ = get_vchunk_array(root["variant_filter"], v_chunk, v_mask_chunk)
     format_fields = {}
     info_fields = {}
     num_samples = len(samples_selection) if samples_selection is not None else None
@@ -346,7 +346,7 @@ def c_chunk_to_vcf(
         else:
             gt_phased = np.zeros_like(gt, dtype=bool)
 
-    for name, zarray in root.items():
+    for name, zarray in root.arrays():
         if (
             name.startswith("call_")
             and not name.startswith("call_genotype")
@@ -442,7 +442,8 @@ def _generate_header(ds, original_header, sample_ids, *, no_version: bool = Fals
         # GT must be the first field if present, per the spec (section 1.6.2)
         format_fields.append("GT")
 
-    for var, arr in ds.items():
+    for var in sorted(ds.keys()):
+        arr = ds[var]
         if (
             var.startswith("variant_")
             and not var.endswith("_fill")


### PR DESCRIPTION
Part of #98

I haven't included tests that run on zarr-python v3, as that requires https://github.com/sgkit-dev/bio2zarr/pull/288 which isn't ready yet. But I managed to run the tests locally under v3 with that change, and they all passed.

This is compatible with zarr-python v2, so it could be merged soon (before the bio2zarr change is done). (But no rush as #105 needs sorting out first.)