### PR TITLE
Fix arch specs in wheel

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,11 +22,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine validate-pyproject[all]
+          python -m pip install build twine auditwheel validate-pyproject[all]
       - name: Check and install package
         run: |
           validate-pyproject pyproject.toml
           python -m build
+          python -m auditwheel repair dist/*.whl
           python -m twine check --strict dist/*
           python -m pip install dist/*.whl
       - name: Check vcztools CLI


### PR DESCRIPTION
Fixes 
`Binary wheel 'vcztools-0.0.1a3-cp311-cp311-linux_x86_64.whl' 
         has an unsupported platform tag 'linux_x86_64'` seen in https://github.com/sgkit-dev/vcztools/actions/runs/13155701384