### PR TITLE
Build wheels in docker 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -21,17 +22,21 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build twine auditwheel validate-pyproject[all]
-      - name: Check and install package
+          python -m pip install --upgrade pip build validate-pyproject[all]
+          python -m build --sdist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - name: Build wheels
         run: |
           validate-pyproject pyproject.toml
-          python -m build
-          python -m auditwheel repair dist/*.whl
-          python -m twine check --strict dist/*
-          python -m pip install dist/*.whl
+          docker run --rm -v `pwd`:/project -w /project quay.io/pypa/manylinux2014_x86_64 bash .github/workflows/docker/buildwheel.sh
       - name: Check vcztools CLI
         run: |
+          pip install numpy "zarr>=2.17,<3" click pyranges pyparsing
+          pip install vcztools --no-index --only-binary vcztools -f dist/wheelhouse
           vcztools --help
           # Make sure we don't have ``vcztools`` in the CWD
           cd tests
@@ -39,8 +44,8 @@ jobs:
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions
-          path: dist/
+          name: linux-wheels
+          path: dist/wheelhouse
 
   publish-to-pypi:
     if: github.repository_owner == 'sgkit-dev' && github.event_name == 'release'
@@ -55,11 +60,14 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download all
+        uses: actions/download-artifact@v4.1.8
+      - name: Move to dist
+        run: |
+          mkdir dist
+          cp */*.{whl,gz} dist/.
+          ls dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
 
 
   publish-to-testpypi:
@@ -76,11 +84,14 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        verbose: true
-        repository-url: https://test.pypi.org/legacy/
+      - name: Download all
+        uses: actions/download-artifact@v4.1.8
+      - name: Move to dist
+        run: |
+          mkdir dist
+          cp */*.{whl,gz} dist/.
+          ls dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/docker/buildwheel.sh
+++ b/.github/workflows/docker/buildwheel.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+DOCKER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DOCKER_DIR/shared.env"
+
+set -e -x
+
+ARCH=`uname -p`
+echo "arch=$ARCH"
+
+# We're running as root in the docker container so git commands issued by
+# setuptools_scm will fail without this:
+git config --global --add safe.directory /project
+# Fetch the full history as we'll be missing tags otherwise.
+git fetch --unshallow
+for V in "${PYTHON_VERSIONS[@]}"; do
+    git reset --hard
+    git clean -fd
+    PYBIN=/opt/python/$V/bin
+    rm -rf build/       # Avoid lib build by one Python is used by another
+    $PYBIN/python -m venv env
+    source env/bin/activate
+    $PYBIN/python -m pip install --upgrade build
+    SETUPTOOLS_SCM_DEBUG=1 $PYBIN/python -m build
+done
+
+cd dist
+for whl in *.whl; do
+    auditwheel -v repair "$whl"
+    rm "$whl"
+done

--- a/.github/workflows/docker/shared.env
+++ b/.github/workflows/docker/shared.env
@@ -1,0 +1,6 @@
+PYTHON_VERSIONS=(
+    cp39-cp39
+    cp310-cp310
+    cp311-cp311
+    cp312-cp312
+)


### PR DESCRIPTION
Fixes "cannot repair "dist/vcztools-0.1.dev1+g89924d7-cp311-cp311-linux_x86_64.whl" to "manylinux_2_5_x86_64" ABI because of the presence of too-recent versioned symbols. You'll need to compile the wheel on an older toolchain."