### PR TITLE
Minimal stuff bugfix for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.0.2] - 2025-04-04
+
+Important bugfixes for filtering language and sample subsetting.
+
+- Clarify the implementation status of the filtering mini-lanuage in
+  view/query. Version 0.0.1 contained several data-corrupting bugs,
+  including incorrect missing data handling (#163), incorrect
+  matching on FILTER (#164) and CHROM (#178) columns, and
+  incorrect per-sample filtering in query (#179). These issues
+  have been resolved by raising informative errors on aspects
+  of the query language that are not implemented correctly.
+
+- The filtering mini-language now consists of arbitrary arithmetic
+  expressions on 1-dimensional fields.
+
+- Add support for specifying samples via -s/-S options
+
 ## [0.0.1] - 2025-02-05
 
 Initial release of vcztools

--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -140,6 +140,7 @@ def test_vcf_output_with_output_option(tmp_path, args, vcf_file):
         ("query --list-samples", "1kg_2020_chrM.vcf.gz"),
         (r"query -f 'A\n'", "sample.vcf.gz"),
         (r"query -f '%CHROM:%POS\n'", "sample.vcf.gz"),
+        (r"query -f '[%CHROM %POS %GT\n]'", "sample.vcf.gz"),
         (r"query -f '%INFO/DP\n'", "sample.vcf.gz"),
         (r"query -f '%AC{0}\n'", "sample.vcf.gz"),
         (r"query -f '%REF\t%ALT\n'", "sample.vcf.gz"),
@@ -152,8 +153,6 @@ def test_vcf_output_with_output_option(tmp_path, args, vcf_file):
         (r"query -f '%POS\n' -e 'POS=112'", "sample.vcf.gz"),
         (r"query -f '[%CHROM\t]\n'", "sample.vcf.gz"),
         (r"query -f '[%CHROM\t]\n' -i 'POS=112'", "sample.vcf.gz"),
-        (r"query -f '%CHROM\t%POS\t%REF\t%ALT[\t%SAMPLE=%GT]\n'", "sample.vcf.gz"),
-        (r"query -f 'GQ:[ %GQ] \t GT:[ %GT]\n'", "sample.vcf.gz"),
         (r"query -f '[%CHROM:%POS %SAMPLE %GT\n]'", "sample.vcf.gz"),
         (r"query -f '[%SAMPLE %GT %DP\n]'", "sample.vcf.gz"),
         (
@@ -164,6 +163,18 @@ def test_vcf_output_with_output_option(tmp_path, args, vcf_file):
             r"query -f '[%POS %QUAL\n]' -i'(QUAL > 10 && POS > 100000)'",
             "sample.vcf.gz",
         ),
+        # Examples from bcftools query documentation
+        (r"query -f '%CHROM  %POS  %REF  %ALT{0}\n'", "sample.vcf.gz"),
+        (r"query -f '%CHROM\t%POS\t%REF\t%ALT[\t%SAMPLE=%GT]\n'", "sample.vcf.gz"),
+        (r"query -f 'GQ:[ %GQ] \t GT:[ %GT]\n'", "sample.vcf.gz"),
+        # POS0 not supported
+        # (r"query -f '%CHROM\t%POS0\t%END\t%ID\n'", "sample.vcf.gz"),
+        # Filtering on GT not supported
+        # (r"query -f [%CHROM:%POS %SAMPLE %GT\n]' -i'GT=\"alt\"'", "sample.vcf.gz"),
+        # Indexing not supported in filtering
+        # (r"query  -f '%AC{1}\n' -i 'AC[1]>10' ", "sample.vcf.gz"),
+        # TODO fill-out more of these when supported for more stuff is available
+        # in filtering
     ],
 )
 def test_output(tmp_path, args, vcf_name):
@@ -211,10 +222,10 @@ def test_query_arithmethic(tmp_path, expr):
     [
         # Check boolean logic evaluation. Will evaluate this with
         # POS=112, so POS=112 is True and POS!=112 is False
-        ("POS==112 || POS!=112",  True),
-        ("POS==112 && POS!=112",  False),
+        ("POS==112 || POS!=112", True),
+        ("POS==112 && POS!=112", False),
         ("POS==112 || POS!=112 && POS!= 112", True),
-        ("(POS==112 || POS!=112) && POS!= 112",  False),
+        ("(POS==112 || POS!=112) && POS!= 112", False),
     ],
 )
 def test_query_logic_precendence(tmp_path, expr, expected):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -261,6 +261,19 @@ class TestBcftoolsParser:
         nt.assert_array_equal(result, evaled)
 
     @pytest.mark.parametrize(
+        ("expr", "data"),
+        [
+            ("a", {"a": [[1], [2], [3]]}),
+        ],
+    )
+    def test_numpy_2d_arithmetic_expressions_data(self, expr, data):
+        parser = filter_mod.make_bcftools_filter_parser(map_vcf_identifiers=False)
+        parsed = parser.parse_string(expr, parse_all=True)
+        npdata = numpify_values(data)
+        with pytest.raises(filter_mod.Unsupported2DFieldsError):
+            parsed[0].eval(npdata)
+
+    @pytest.mark.parametrize(
         ("expr", "expected"),
         [
             ("1 & 1", True),

--- a/tests/test_plink_validation.py
+++ b/tests/test_plink_validation.py
@@ -21,6 +21,7 @@ def assert_files_identical(path1, path2):
     assert b1 == b2
 
 
+@pytest.mark.skip("Removing plink from CLI for bugfix release")
 # fmt: off
 @pytest.mark.parametrize(
     ("args", "vcf_file"),
@@ -30,7 +31,7 @@ def assert_files_identical(path1, path2):
         ("", "1kg_2020_chrM.vcf.gz"),
         # FIXME this needs some extra args to deal with sample ID format
         # ("", "msprime_diploid.vcf.gz"),
-    ]
+    ],
 )
 # fmt: on
 def test_conversion_identical(tmp_path, args, vcf_file):

--- a/vcztools/cli.py
+++ b/vcztools/cli.py
@@ -286,4 +286,4 @@ def vcztools_main():
 vcztools_main.add_command(index)
 vcztools_main.add_command(query)
 vcztools_main.add_command(view)
-vcztools_main.add_command(view_plink1)
+# vcztools_main.add_command(view_plink1)

--- a/vcztools/filter.py
+++ b/vcztools/filter.py
@@ -57,6 +57,11 @@ class UnsupportedFunctionsError(UnsupportedFilteringFeatureError):
     feature = "Function evaluation"
 
 
+class Unsupported2DFieldsError(UnsupportedFilteringFeatureError):
+    issue = "193"
+    feature = "2D INFO fields"
+
+
 # The parser and evaluation model here are based on the eval_arith example
 # in the pyparsing docs:
 # https://github.com/pyparsing/pyparsing/blob/master/examples/eval_arith.py
@@ -110,7 +115,10 @@ class Identifier(EvaluationNode):
         logger.debug(f"Mapped {tokens[0]} to {self.field_name}")
 
     def eval(self, data):
-        return data[self.field_name]
+        value = np.asarray(data[self.field_name])
+        if len(value.shape) > 1:
+            raise Unsupported2DFieldsError()
+        return value
 
     def __repr__(self):
         return self.field_name


### PR DESCRIPTION
This temporarily pulls the plink command from the CLI and tidies up a few other details in the filter language. I think it's important to get this released now, as filtering is core functionality and we don't want potential users getting the wrong ideas.

There's something weird going on with lint noise, which I'll try and figure out.