### PR TITLE
Support TYPE field (ref and snp)

### DIFF
--- a/tests/test_bcftools_validation.py
+++ b/tests/test_bcftools_validation.py
@@ -70,6 +70,8 @@ def run_vcztools(args: str, expect_error=False) -> tuple[str, str]:
                 "view --no-version -e '(FMT/DP >= 8 | FMT/GQ>40) && POS > 100000'",
                 "sample.vcf.gz"
         ),
+        ("view --no-version -i 'TYPE=\"ref\"'", "sample.vcf.gz"),
+        ("view --no-version -i 'TYPE=\"snp\"'", "sample.vcf.gz"),
         ("view --no-version -G", "sample.vcf.gz"),
         (
                 "view --no-update --no-version --samples-file "

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -1,0 +1,18 @@
+import pytest
+
+from vcztools.calculate import REF, SNP, UNCLASSIFIED, get_variant_type
+
+
+@pytest.mark.parametrize(
+    ("ref", "alt", "expected_type"),
+    [
+        ("A", "T", SNP),
+        ("A", "A", REF),
+        ("A", "<NON_REF>", REF),
+        ("A", "<*>", REF),
+        ("A", "", REF),
+        ("A", "AA", UNCLASSIFIED),
+    ],
+)
+def test_get_variant_type(ref, alt, expected_type):
+    assert get_variant_type(ref, alt) == expected_type

--- a/vcztools/calculate.py
+++ b/vcztools/calculate.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+# Variant types
+REF = -1  # missing value
+SNP = 1 << 0
+UNCLASSIFIED = 1 << 8
+
+
+def get_variant_type(ref: str, alt: str) -> int:
+    """Return the variant type int for the given REF, ALT combination."""
+    if len(alt) == 0:
+        return REF
+    elif len(ref) == 1 and len(alt) == 1 and alt != "*":
+        if ref == alt:
+            return REF
+        else:
+            return SNP
+    elif alt == "<*>" or alt == "<NON_REF>":
+        return REF
+    else:
+        return UNCLASSIFIED
+
+
+def calculate_variant_type(variant_allele: np.ndarray) -> np.ndarray:
+    """Calculate the variant type array from the variant_allele array."""
+    ref = variant_allele[:, 0]
+    alt = variant_allele[:, 1:]
+
+    variant_type = np.zeros(alt.shape, dtype=np.int16)
+
+    for i in range(alt.shape[0]):
+        for j in range(alt.shape[1]):
+            variant_type[i, j] = get_variant_type(ref[i], alt[i, j])
+    return variant_type

--- a/vcztools/filter.py
+++ b/vcztools/filter.py
@@ -5,6 +5,8 @@ import operator
 import numpy as np
 import pyparsing as pp
 
+from vcztools.calculate import SNP, calculate_variant_type
+
 from .utils import vcf_name_to_vcz_name
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,11 @@ class UnsupportedMissingDataError(UnsupportedFilteringFeatureError):
 class UnsupportedGenotypeValuesError(UnsupportedFilteringFeatureError):
     issue = "165"
     feature = "Genotype values"
+
+
+class UnsupportedTypeFieldError(UnsupportedFilteringFeatureError):
+    issue = "166"
+    feature = "TYPE field (except 'ref' and 'snp')"
 
 
 class UnsupportedArraySubscriptError(UnsupportedFilteringFeatureError):
@@ -392,6 +399,75 @@ class FilterFieldOperator(EvaluationNode):
         return self.op1.referenced_fields() | self.op2.referenced_fields()
 
 
+def type_eq(a, b):
+    if b == "ref":
+        return np.all(a < 0, axis=1)
+    elif b == "snp":
+        all_a = np.bitwise_and.reduce(a, axis=1)
+        all_a = np.where(all_a < 0, 0, all_a)  # remove missing
+        return np.bitwise_and(all_a, SNP) == SNP
+    else:
+        raise NotImplementedError(f"TYPE comparison not implemented for '{b}'")
+
+
+def type_ne(a, b):
+    return ~type_eq(a, b)
+
+
+def type_subset_match(a, b):
+    if b == "ref":
+        return np.all(a < 0, axis=1)
+    elif b == "snp":
+        any_a = np.where(a < 0, 0, a)  # remove missing
+        any_a = np.bitwise_or.reduce(any_a, axis=1)
+        return np.bitwise_and(any_a, SNP) == SNP
+    else:
+        raise NotImplementedError(f"TYPE comparison not implemented for '{b}'")
+
+
+def type_complement_match(a, b):
+    return ~type_subset_match(a, b)
+
+
+class TypeIdentifier(EvaluationNode):
+    def eval(self, data):
+        variant_allele = np.asarray(data["variant_allele"])
+        variant_type = calculate_variant_type(variant_allele)
+        return variant_type
+
+    def __repr__(self):
+        return "variant_allele"
+
+    def referenced_fields(self):
+        return frozenset(["variant_allele"])
+
+
+class TypeOperator(EvaluationNode):
+    op_map = {
+        "=": type_eq,
+        "==": type_eq,
+        "!=": type_ne,
+        "~": type_subset_match,
+        "!~": type_complement_match,
+    }
+
+    def __init__(self, tokens):
+        super().__init__(tokens)
+        self.op1, self.op, self.op2 = tokens
+        if self.op2 not in ("ref", "snp"):
+            raise UnsupportedTypeFieldError()
+        self.comparison_fn = self.op_map[self.op]
+
+    def eval(self, data):
+        return self.comparison_fn(self.op1.eval(data), self.op2)
+
+    def __repr__(self):
+        return f"({repr(self.op1)}){self.op}({repr(self.op2)})"
+
+    def referenced_fields(self):
+        return self.op1.referenced_fields()
+
+
 def _identity(x):
     return x
 
@@ -432,6 +508,12 @@ def make_bcftools_filter_parser(all_fields=None, map_vcf_identifiers=True):
     filter_field_expr = filter_field_identifier + pp.one_of("= != ~ !~") + filter_string
     filter_field_expr = filter_field_expr.set_parse_action(FilterFieldOperator)
 
+    type_identifier = pp.Literal("TYPE")
+    type_identifier = type_identifier.set_parse_action(TypeIdentifier)
+    type_string = pp.QuotedString('"')
+    type_expr = type_identifier + pp.one_of("= == != ~ !~") + type_string
+    type_expr = type_expr.set_parse_action(TypeOperator)
+
     lbracket, rbracket = map(pp.Suppress, "[]")
     # TODO we need to define the indexing grammar more carefully, but
     # this at least let's us match correct strings and raise an informative
@@ -460,6 +542,7 @@ def make_bcftools_filter_parser(all_fields=None, map_vcf_identifiers=True):
     filter_expression = pp.infix_notation(
         chrom_field_expr
         | filter_field_expr
+        | type_expr
         | function
         | constant
         | indexed_identifier


### PR DESCRIPTION
Partial fix for #166 

TYPE filtering is mainly needed for restricting to SNPs (see e.g. https://github.com/browning-lab/ukb-phasing/blob/master/phase.ukb), so I've only implemented `ref` and `snp`. I've written it so that other types are easy to add later, as long as there are clear rules for how to classify each type.

I've also introduced a `calculate` module. The idea is to consolidate code for calculating fields there - including the existing code for AC and AN, as well as the functions we'll need for calculated variables in #171.

 